### PR TITLE
Fix slow response from ims.gov.il

### DIFF
--- a/weatheril/__init__.py
+++ b/weatheril/__init__.py
@@ -18,6 +18,9 @@ radar_url = "https://ims.gov.il/{}/radar_satellite"
 current_analysis_url = "https://ims.gov.il/{}/now_analysis"
 weather_codes_url = "https://ims.gov.il/{}/weather_codes"
 
+# ims.gov.il does not support ipv6 yet, `requests` use ipv6 by default
+# and wait for timeout before trying ipv4, so we have to disable ipv6
+requests.packages.urllib3.util.connection.HAS_IPV6=False
 
 HE_WEATHER_CODES = {
         "1250": "בהיר",


### PR DESCRIPTION
I noticed that when I query ims.gov.il with `requests` it takes very long time to get the response, but when I use curl or web browser I get the response very quickly.
I found the solution in https://stackoverflow.com/questions/62599036/python-requests-is-slow-and-takes-very-long-to-complete-http-or-https-request
The reason is that `requests` first tries an IPv6 connection. When that times out, it tries to connect via IPv4.
Because ims.gov.il not support ipv6 for some reason, it causes the response time to grow as we have to wait for the timeout first.