### PR TITLE
Change uvi factor type to float

### DIFF
--- a/weatheril/__init__.py
+++ b/weatheril/__init__.py
@@ -89,7 +89,7 @@ class WeatherIL:
                                u_v_index=int(analysis_data.get("u_v_index", "0") or "0"),
                                u_v_level=analysis_data.get("u_v_level"),
                                u_v_i_max=int(analysis_data.get("u_v_i_max", "0") or "0"),
-                               u_v_i_factor=int(float(analysis_data.get("u_v_i_factor", "0")) or "0"),
+                               u_v_i_factor=float(analysis_data.get("u_v_i_factor", "0") or "0"),
                                wave_height=float(analysis_data.get("wave_height", "0.0") or "0.0"),
                                forecast_time=datetime.strptime(analysis_data.get("forecast_time"), '%Y-%m-%d %H:%M:%S'),
                                json=analysis_data,

--- a/weatheril/__init__.py
+++ b/weatheril/__init__.py
@@ -89,7 +89,7 @@ class WeatherIL:
                                u_v_index=int(analysis_data.get("u_v_index", "0") or "0"),
                                u_v_level=analysis_data.get("u_v_level"),
                                u_v_i_max=int(analysis_data.get("u_v_i_max", "0") or "0"),
-                               u_v_i_factor=int(analysis_data.get("u_v_i_factor", "0") or "0"),
+                               u_v_i_factor=int(float(analysis_data.get("u_v_i_factor", "0")) or "0"),
                                wave_height=float(analysis_data.get("wave_height", "0.0") or "0.0"),
                                forecast_time=datetime.strptime(analysis_data.get("forecast_time"), '%Y-%m-%d %H:%M:%S'),
                                json=analysis_data,

--- a/weatheril/weather.py
+++ b/weatheril/weather.py
@@ -24,7 +24,7 @@ class Weather:
     u_v_index: int
     u_v_level: str
     u_v_i_max: int
-    u_v_i_factor: int
+    u_v_i_factor: float
     json: str
     weather_code: str
     wave_height: float


### PR DESCRIPTION
Sometimes the UV data comes as a float string ('0.8'), and it causes `ValueError: invalid literal for int() with base 10: '0.8'`